### PR TITLE
Added Missing Close button on settings popup

### DIFF
--- a/Enchanted/UI/Shared/Settings/SettingsView.swift
+++ b/Enchanted/UI/Shared/Settings/SettingsView.swift
@@ -26,7 +26,6 @@ struct SettingsView: View {
         VStack {
             ZStack {
                 HStack {
-#if os(macOS)
                     Button {
                         presentationMode.wrappedValue.dismiss()
                     } label: {
@@ -34,7 +33,6 @@ struct SettingsView: View {
                             .font(.system(size: 16))
                             .foregroundStyle(Color(.label))
                     }
-#endif
                     
 
                     Spacer()

--- a/Enchanted/UI/Shared/Settings/SettingsView.swift
+++ b/Enchanted/UI/Shared/Settings/SettingsView.swift
@@ -26,6 +26,17 @@ struct SettingsView: View {
         VStack {
             ZStack {
                 HStack {
+#if os(macOS)
+                    Button {
+                        presentationMode.wrappedValue.dismiss()
+                    } label: {
+                        Text("Cancel")
+                            .font(.system(size: 16))
+                            .foregroundStyle(Color(.label))
+                    }
+#endif
+                    
+
                     Spacer()
                     
                     Button(action: save) {


### PR DESCRIPTION
There is no way to close the settings popup other than clicking on the save button.

**_Issue_**
<img width="70%" alt="Screenshot 2024-02-25 at 10 22 00 PM" src="https://github.com/AugustDev/enchanted/assets/4938757/31434155-b250-48db-b22b-e6da43b23dc1">

**_Fixed_** 
<img width="70%" alt="Screenshot 2024-02-25 
![Screenshot 2024-02-26 at 8 31 15 PM](https://github.com/AugustDev/enchanted/assets/4938757/c0700d41-36fd-4383-9730-121c4e21d7d7)
at 10 19 34 PM" src="https://github.com/AugustDev/enchanted/assets/4938757/c6ce19f0-b194-415b-a3ea-aaa581fedfd2">

<img src="https://github.com/AugustDev/enchanted/assets/4938757/6f74e22f-9b13-47f3-abdf-3498574a3090">




