### PR TITLE
Add menu item to open Settings

### DIFF
--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3396E0762BD877D500213816 /* Menus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3396E0752BD877D500213816 /* Menus.swift */; };
 		FF0146CB2B3DA1DF00A2A9F6 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0146CA2B3DA1DF00A2A9F6 /* Settings.swift */; };
 		FF0146CD2B3DADCA00A2A9F6 /* HapticsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0146CC2B3DADCA00A2A9F6 /* HapticsService.swift */; };
 		FF1002302B2482BA0011A4DC /* ChatMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10022F2B2482BA0011A4DC /* ChatMessageView.swift */; };
@@ -94,6 +95,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3396E0752BD877D500213816 /* Menus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Menus.swift; sourceTree = "<group>"; };
 		FF0146CA2B3DA1DF00A2A9F6 /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		FF0146CC2B3DADCA00A2A9F6 /* HapticsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticsService.swift; sourceTree = "<group>"; };
 		FF10022F2B2482BA0011A4DC /* ChatMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageView.swift; sourceTree = "<group>"; };
@@ -324,6 +326,7 @@
 		FF66A51E2B77788D00FAAC1E /* macOS */ = {
 			isa = PBXGroup;
 			children = (
+				3396E0752BD877D500213816 /* Menus.swift */,
 				FF9300D52B778F1A000859F4 /* Chat */,
 				FF6D821A2B9141F0001183A8 /* CompletionsEditor */,
 				FF464B172B810966008E5130 /* Components */,
@@ -660,6 +663,7 @@
 				FF10024E2B25C2A70011A4DC /* ConversationSD.swift in Sources */,
 				FFEC32912B24779A003E5C04 /* EnchantedApp.swift in Sources */,
 				FF2F03422B795E0B00349855 /* Clipboard.swift in Sources */,
+				3396E0762BD877D500213816 /* Menus.swift in Sources */,
 				FF9300DA2B781D97000859F4 /* ToolbarView_macOS.swift in Sources */,
 				FF1002522B2609980011A4DC /* ModelContext+Extension.swift in Sources */,
 				FF1002752B278C170011A4DC /* AppStore.swift in Sources */,

--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -802,7 +802,7 @@
 				CODE_SIGN_ENTITLEMENTS = Enchanted/Enchanted.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Enchanted/Preview Content\"";
 				DEVELOPMENT_TEAM = JDDZ55DT74;
@@ -851,7 +851,7 @@
 				CODE_SIGN_ENTITLEMENTS = Enchanted/Enchanted.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 22;
+				CURRENT_PROJECT_VERSION = 23;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Enchanted/Preview Content\"";
 				DEVELOPMENT_TEAM = JDDZ55DT74;

--- a/Enchanted/Application/EnchantedApp.swift
+++ b/Enchanted/Application/EnchantedApp.swift
@@ -34,6 +34,8 @@ struct EnchantedApp: App {
                     NSWindow.allowsAutomaticWindowTabbing = false
                 }
 #endif
+        }.commands {
+            Menus()
         }
 #if os(macOS)
         Window("Keyboard Shortcuts", id: "keyboard-shortcuts") {

--- a/Enchanted/UI/Shared/Sidebar/SidebarView.swift
+++ b/Enchanted/UI/Shared/Sidebar/SidebarView.swift
@@ -48,6 +48,7 @@ struct SidebarView: View {
             
         }
         .padding()
+        .focusedSceneValue(\.showSettings, $showSettings)
         .sheet(isPresented: $showSettings) {
             Settings()
         }

--- a/Enchanted/UI/macOS/Menus.swift
+++ b/Enchanted/UI/macOS/Menus.swift
@@ -1,0 +1,36 @@
+//
+//  Menus.swift
+//  Enchanted
+//
+//  Created by Wildan Zulfikar on 24.4.2024.
+//
+
+import Foundation
+import SwiftUI
+
+#if os(macOS)
+struct ShowSettingsKey: FocusedValueKey {
+    typealias Value = Binding<Bool>
+}
+
+extension FocusedValues {
+    var showSettings: Binding<Bool>? {
+        get { self[ShowSettingsKey.self] }
+        set { self[ShowSettingsKey.self] = newValue }
+    }
+}
+
+struct Menus: Commands {
+   @FocusedValue(\.showSettings) var showSettings
+
+   var body: some Commands {
+       SidebarCommands()
+       CommandGroup(replacing: .appSettings) {
+           Button("Settings") {
+               showSettings?.wrappedValue = true
+           }
+           .keyboardShortcut(",", modifiers: .command)
+       }
+  }
+}
+#endif

--- a/Enchanted/UI/macOS/Menus.swift
+++ b/Enchanted/UI/macOS/Menus.swift
@@ -24,7 +24,6 @@ struct Menus: Commands {
    @FocusedValue(\.showSettings) var showSettings
 
    var body: some Commands {
-       SidebarCommands()
        CommandGroup(replacing: .appSettings) {
            Button("Settings") {
                showSettings?.wrappedValue = true


### PR DESCRIPTION
So we can trigger the settings by pressing `cmd+,` (common macOS shortcut for settings/preferences).

Before/after:

![image](https://github.com/AugustDev/enchanted/assets/7823011/53d7751b-43f2-4a49-ba42-7e5384a2be7f)

Settings page:

![image](https://github.com/AugustDev/enchanted/assets/7823011/e1648190-d958-4bf4-a2dd-1dc3102b3371)

