### PR TITLE
fix: settings shortcut ignored for ios

### DIFF
--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 				CODE_SIGN_ENTITLEMENTS = Enchanted/Enchanted.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Enchanted/Preview Content\"";
 				DEVELOPMENT_TEAM = JDDZ55DT74;
@@ -830,7 +830,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = subj.Enchanted;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -853,7 +853,7 @@
 				CODE_SIGN_ENTITLEMENTS = Enchanted/Enchanted.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 25;
+				CURRENT_PROJECT_VERSION = 26;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"Enchanted/Preview Content\"";
 				DEVELOPMENT_TEAM = JDDZ55DT74;
@@ -879,7 +879,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.1;
+				MARKETING_VERSION = 1.6.2;
 				PRODUCT_BUNDLE_IDENTIFIER = subj.Enchanted;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/Enchanted/Application/EnchantedApp.swift
+++ b/Enchanted/Application/EnchantedApp.swift
@@ -34,9 +34,12 @@ struct EnchantedApp: App {
                     NSWindow.allowsAutomaticWindowTabbing = false
                 }
 #endif
-        }.commands {
+        }
+#if os(macOS)
+        .commands {
             Menus()
         }
+#endif
 #if os(macOS)
         Window("Keyboard Shortcuts", id: "keyboard-shortcuts") {
             KeyboardShortcutsDemo()

--- a/Enchanted/UI/Shared/Sidebar/SidebarView.swift
+++ b/Enchanted/UI/Shared/Sidebar/SidebarView.swift
@@ -48,7 +48,9 @@ struct SidebarView: View {
             
         }
         .padding()
+#if os(macOS)
         .focusedSceneValue(\.showSettings, $showSettings)
+#endif
         .sheet(isPresented: $showSettings) {
             Settings()
         }


### PR DESCRIPTION
Settings shortcut ignored for iOS