### PR TITLE
Add indicator for selected conversation in conversation list

### DIFF
--- a/Enchanted/UI/Shared/Chat/Chat.swift
+++ b/Enchanted/UI/Shared/Chat/Chat.swift
@@ -112,6 +112,7 @@ struct Chat: View {
 #else
             SideBarStack(sidebarWidth: 300,showSidebar: $showMenu, sidebar: {
                 SidebarView(
+                    selectedConversation: conversationStore.selectedConversation,
                     conversations: conversationStore.conversations,
                     onConversationTap: onConversationTap,
                     onConversationDelete: onConversationDelete,

--- a/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
+++ b/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
@@ -22,6 +22,7 @@ struct ConversationGroup: Hashable {
 }
 
 struct ConversationHistoryList: View {
+    var selectedConversation: ConversationSD?
     var conversations: [ConversationSD]
     var onTap: (_ conversation: ConversationSD) -> ()
     var onDelete: (_ conversation: ConversationSD) -> ()
@@ -62,6 +63,12 @@ struct ConversationHistoryList: View {
                 ForEach(conversationGroup.conversations, id:\.self) { dailyConversation in
                     HStack {
                         Button(action: {onTap(dailyConversation)}) {
+                            let isSelected = selectedConversation?.name == dailyConversation.name && selectedConversation?.createdAt == dailyConversation.createdAt
+                            if isSelected {
+                                Text("•")
+                                    .font(.system(size: 16))
+                                    .foregroundColor(.blue)
+                            }
                             Text(dailyConversation.name)
                                 .lineLimit(1)
                                 .font(.system(size: 16))

--- a/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
+++ b/Enchanted/UI/Shared/Sidebar/Components/ConversationHistoryListView.swift
@@ -61,23 +61,25 @@ struct ConversationHistoryList: View {
                 })
                 
                 ForEach(conversationGroup.conversations, id:\.self) { dailyConversation in
-                    HStack {
-                        Button(action: {onTap(dailyConversation)}) {
-                            let isSelected = selectedConversation?.name == dailyConversation.name && selectedConversation?.createdAt == dailyConversation.createdAt
-                            if isSelected {
-                                Text("•")
-                                    .font(.system(size: 16))
-                                    .foregroundColor(.blue)
-                            }
+                    Button(action: {onTap(dailyConversation)}) {
+                        HStack {
+                            Circle()
+                                .frame(width: 6, height: 6)
+                                .animation(.easeOut(duration: 0.15))
+                                .transition(.opacity)
+                                .showIf(selectedConversation == dailyConversation)
+                            
                             Text(dailyConversation.name)
                                 .lineLimit(1)
                                 .font(.system(size: 16))
-                                .fontWeight(.regular)
                                 .foregroundColor(Color(.label))
+                                .animation(.easeOut(duration: 0.15))
+                                .transition(.opacity)
                             Spacer()
                         }
-                        .buttonStyle(.plain)
+                        .animation(.easeOut(duration: 0.15))
                     }
+                    .buttonStyle(.plain)
                     .contextMenu(menuItems: {
                         Button(role: .destructive, action: { onDelete(dailyConversation) }) {
                             Label("Delete", systemImage: "trash")
@@ -93,5 +95,5 @@ struct ConversationHistoryList: View {
 
 
 #Preview {
-        ConversationHistoryList(conversations: ConversationSD.sample, onTap: {_ in}, onDelete: {_ in}, onDeleteDailyConversations: {_ in})
+    ConversationHistoryList(selectedConversation: ConversationSD.sample[0], conversations: ConversationSD.sample, onTap: {_ in}, onDelete: {_ in}, onDeleteDailyConversations: {_ in})
 }

--- a/Enchanted/UI/Shared/Sidebar/SidebarView.swift
+++ b/Enchanted/UI/Shared/Sidebar/SidebarView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct SidebarView: View {
     @Environment(\.openWindow) var openWindow
+    var selectedConversation: ConversationSD?
     var conversations: [ConversationSD]
     var onConversationTap: (_ conversation: ConversationSD) -> ()
     var onConversationDelete: (_ conversation: ConversationSD) -> ()
@@ -28,6 +29,7 @@ struct SidebarView: View {
         VStack {
             ScrollView() {
                 ConversationHistoryList(
+                    selectedConversation: selectedConversation,
                     conversations: conversations,
                     onTap: onConversationTap,
                     onDelete: onConversationDelete,
@@ -67,5 +69,5 @@ struct SidebarView: View {
 }
 
 #Preview {
-    SidebarView(conversations: ConversationSD.sample, onConversationTap: {_ in}, onConversationDelete: {_ in}, onDeleteDailyConversations: {_ in})
+    SidebarView(selectedConversation: ConversationSD.sample[0], conversations: ConversationSD.sample, onConversationTap: {_ in}, onConversationDelete: {_ in}, onDeleteDailyConversations: {_ in})
 }

--- a/Enchanted/UI/macOS/Chat/ChatView_macOS.swift
+++ b/Enchanted/UI/macOS/Chat/ChatView_macOS.swift
@@ -34,6 +34,7 @@ struct ChatView: View {
     var body: some View {
         NavigationSplitView(columnVisibility: $columnVisibility) {
             SidebarView(
+                selectedConversation: selectedConversation,
                 conversations: conversations,
                 onConversationTap: onConversationTap,
                 onConversationDelete: onConversationDelete,


### PR DESCRIPTION
**What**
Add `selectedConversation` to `ConversationHistoryListView` to determine when to show the indicator.

Before (no indicator for selected conversation):

https://github.com/AugustDev/enchanted/assets/7823011/6700f0fc-76b9-42fd-89df-184be16aaf0b

After (selected conversation has blue indicator):

https://github.com/AugustDev/enchanted/assets/7823011/71ceec83-b5c7-44db-947a-a40bac795353

**Why**
When selecting other conversation from the list, I noticed I had difficulty figuring out what's the currently selected conversation. This PR adds a little indicator to the selected conversation.