### PR TITLE
Settings - Ollama Ping Interval

### DIFF
--- a/Enchanted/Stores/AppStore.swift
+++ b/Enchanted/Stores/AppStore.swift
@@ -15,12 +15,16 @@ final class AppStore {
     
     private var cancellables = Set<AnyCancellable>()
     private var timer: Timer?
+    private var pingInterval: TimeInterval = 5
     @MainActor var isReachable: Bool = true
     @MainActor var notifications: [NotificationMessage] = []
     @MainActor var menuBarIcon: String? = nil
 
     init() {
-        startCheckingReachability()
+        if let storedIntervalString = UserDefaults.standard.string(forKey: "pingInterval") {
+            pingInterval = Double(storedIntervalString) ?? 5
+        }
+        startCheckingReachability(interval: pingInterval)
     }
     
     deinit {

--- a/Enchanted/Stores/AppStore.swift
+++ b/Enchanted/Stores/AppStore.swift
@@ -23,6 +23,10 @@ final class AppStore {
     init() {
         if let storedIntervalString = UserDefaults.standard.string(forKey: "pingInterval") {
             pingInterval = Double(storedIntervalString) ?? 5
+            
+            if pingInterval <= 0 {
+                pingInterval = .infinity
+            }
         }
         startCheckingReachability(interval: pingInterval)
     }

--- a/Enchanted/UI/Shared/Settings/Settings.swift
+++ b/Enchanted/UI/Shared/Settings/Settings.swift
@@ -18,6 +18,7 @@ struct Settings: View {
     @AppStorage("defaultOllamaModel") private var defaultOllamaModel: String = ""
     @AppStorage("ollamaBearerToken") private var ollamaBearerToken: String = ""
     @AppStorage("appUserInitials") private var appUserInitials: String = ""
+    @AppStorage("pingInterval") private var pingInterval: String = "5"
     
     @Environment(\.presentationMode) var presentationMode
     
@@ -59,6 +60,7 @@ struct Settings: View {
             defaultOllamModel: $defaultOllamaModel, 
             ollamaBearerToken: $ollamaBearerToken,
             appUserInitials: $appUserInitials,
+            pingInterval: $pingInterval,
             save: save,
             checkServer: checkServer,
             deleteAllConversations: conversationStore.deleteAllConversations,

--- a/Enchanted/UI/Shared/Settings/SettingsView.swift
+++ b/Enchanted/UI/Shared/Settings/SettingsView.swift
@@ -16,6 +16,7 @@ struct SettingsView: View {
     @Binding var defaultOllamModel: String
     @Binding var ollamaBearerToken: String
     @Binding var appUserInitials: String
+    @Binding var pingInterval: String
     @State var ollamaStatus: Bool?
     var save: () -> ()
     var checkServer: () -> ()
@@ -101,6 +102,9 @@ struct SettingsView: View {
     #if os(iOS)
                         .autocapitalization(.none)
     #endif
+                    TextField("Ping Interval (seconds)", text: $pingInterval)
+                        .disableAutocorrection(true)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
                     
                     Section(header: Text("APP").font(.headline).padding(.top, 20)) {
                         
@@ -164,6 +168,7 @@ struct SettingsView: View {
         defaultOllamModel: .constant("llama2"),
         ollamaBearerToken: .constant("x"),
         appUserInitials: .constant("AM"),
+        pingInterval: .constant("5"),
         save: {},
         checkServer: {},
         deleteAllConversations: {},


### PR DESCRIPTION
Adding a setting to set the interval in seconds when the app should check if the Ollama service is reachable. Default is `5` seconds.

Aims to solve:

- https://github.com/AugustDev/enchanted/issues/78
- https://github.com/AugustDev/enchanted/issues/73

**DISCLAIMER**: I am not a swift dev. Everything coded using AI. Improvement suggestions are welcomed!