### PR TITLE
fix: floating button overlap on MacOS

### DIFF
--- a/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
+++ b/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
@@ -64,21 +64,34 @@ struct InputFieldsView: View {
                 .padding(5)
             }
             
-            TextField("Message", text: $message.animation(.easeOut(duration: 0.3)), axis: .vertical)
-                .focused($isFocusedInput)
-                .frame(minHeight: 40)
-                .font(.system(size: 14))
-                .textFieldStyle(.plain)
-                .onSubmit {
-                    if NSApp.currentEvent?.modifierFlags.contains(.shift) == true {
-                        message += "\n"
-                    } else {
-                        sendMessage()
+            ZStack(alignment: .trailing) {
+                TextField("Message", text: $message.animation(.easeOut(duration: 0.3)), axis: .vertical)
+                    .focused($isFocusedInput)
+                    .frame(minHeight: 40)
+                    .font(.system(size: 14))
+                    .textFieldStyle(.plain)
+                    .onSubmit {
+                        if NSApp.currentEvent?.modifierFlags.contains(.shift) == true {
+                            message += "\n"
+                        } else {
+                            sendMessage()
+                        }
                     }
+                /// TextField bypasses drop area
+                    .allowsHitTesting(!fileDropActive)
+                    .addCustomHotkeys(hotkeys)
+                    .padding(.trailing, 40)
+                
+                switch conversationState {
+                case .loading:
+                    SimpleFloatingButton(systemImage: "square.fill", onClick: onStopGenerateTap)
+                        .padding(.trailing, 6)
+                default:
+                    SimpleFloatingButton(systemImage: "paperplane.fill", onClick: { Task { sendMessage() } })
+                        .showIf(!message.isEmpty)
+                        .padding(.trailing, 6)
                 }
-            /// TextField bypasses drop area
-                .allowsHitTesting(!fileDropActive)
-                .addCustomHotkeys(hotkeys)
+            }
             
             SimpleFloatingButton(systemImage: "photo.fill", onClick: { fileSelectingActive.toggle() })
                 .showIf(selectedModel?.supportsImages ?? false)
@@ -97,15 +110,6 @@ struct InputFieldsView: View {
                         print(error)
                     }
                 })
-            
-            
-            switch conversationState {
-            case .loading:
-                SimpleFloatingButton(systemImage: "square.fill", onClick: onStopGenerateTap)
-            default:
-                SimpleFloatingButton(systemImage: "paperplane.fill", onClick: { Task { sendMessage() } })
-                    .showIf(!message.isEmpty)
-            }
         }
         .transition(.slide)
         .padding(.horizontal)

--- a/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
+++ b/Enchanted/UI/macOS/Chat/Components/InputFields_macOS.swift
@@ -80,16 +80,14 @@ struct InputFieldsView: View {
                 /// TextField bypasses drop area
                     .allowsHitTesting(!fileDropActive)
                     .addCustomHotkeys(hotkeys)
-                    .padding(.trailing, 40)
+                    .padding(.trailing, 30)
                 
                 switch conversationState {
                 case .loading:
                     SimpleFloatingButton(systemImage: "square.fill", onClick: onStopGenerateTap)
-                        .padding(.trailing, 6)
                 default:
                     SimpleFloatingButton(systemImage: "paperplane.fill", onClick: { Task { sendMessage() } })
                         .showIf(!message.isEmpty)
-                        .padding(.trailing, 6)
                 }
             }
             


### PR DESCRIPTION
## Issue Description

The floating button will overlap with InputFieldsView's `TextField` object, causing the user's input to disappear behind the button. Adjusting the TextField's padding and/or offset within the HStack did not seem to resolve this issue. Text would still disappear behind the adjusted spacing.

## Proposed Solution

Embed the `TextField` and conversationState's `SimpleFloatingButton` objects within a ZStack that uses trailing alignment. The `TextField` will fit its container, but then has a trailing offset by the `SimpleFloatingButton`'s adjusted size.

### Before Fix

https://github.com/AugustDev/enchanted/assets/158503966/f0cabb56-bfb5-4c95-acc1-9f7894aed016

### After Fix

https://github.com/AugustDev/enchanted/assets/158503966/37a3e490-3f0a-42a5-a4c2-e6c4a35092f2