### PR TITLE
Switch back to mainline swift-markdown-ui

### DIFF
--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -1048,10 +1048,10 @@
 		};
 		FFF993572BDFBDCC004DCF19 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/AugustDev/swift-markdown-ui";
+			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
 			};
 		};
 		FFFD00C72B94CB5E00392AE6 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {

--- a/Enchanted.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Enchanted.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2ecdf9d081540d56a3d35c3ac234eabac50668e7cc364d29a44a05e51449bba1",
+  "originHash" : "a828c57bb38e56bc4d70b841d1884d7217e063fbe9ad3dd2f867b7f5b7b2822c",
   "pins" : [
     {
       "identity" : "activityindicatorview",
@@ -94,10 +94,10 @@
     {
       "identity" : "swift-markdown-ui",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/AugustDev/swift-markdown-ui",
+      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
       "state" : {
-        "branch" : "main",
-        "revision" : "acb83e45394334a04ba0cf3487e4d07f4709eeb4"
+        "revision" : "55441810c0f678c78ed7e2ebd46dde89228e02fc",
+        "version" : "2.4.0"
       }
     },
     {


### PR DESCRIPTION
The project currently does not build on Xcode 16, due to the issue in https://github.com/AugustDev/swift-markdown-ui. This was reported as an issue on this project:
* #154

The upstream repo https://github.com/gonzalezreal/swift-markdown-ui includes the fix to the Xcode 16 build issue:
* https://github.com/gonzalezreal/swift-markdown-ui/pull/328

This PR fixes the project by switching over to the upstream `swift-markdown-ui` dependency.
