### PR TITLE
Add OpenRouter Proxy Server for Non-Local LLM Usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ You're done! Make a prompt.
 
    You're done! Make a prompt.
 
+You can also use the OpenRouter proxy if you'd like to work with non-local models. To do this, you'll need to run the proxy server:
+https://github.com/xsharov/enchanted-ollama-openrouter-proxy
+
 # Contact
 
 For any questions please do not hesitate to contact me at augustinas@subj.org


### PR DESCRIPTION
This pull request introduces a proxy server that emulates the Ollama API but directs requests to OpenRouter instead. This feature is particularly useful for users who prefer not to rely on locally hosted LLMs. By running this proxy, they can seamlessly utilize remote models while retaining the familiar Ollama-compatible API.