### PR TITLE
Add OpenAI-compatible API provider support

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -2,7 +2,7 @@ name: Build iOS App
 
 on:
   push:
-    branches: [main, 'claude/*']
+    branches: [main]
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -1,0 +1,182 @@
+name: Build iOS App
+
+on:
+  push:
+    branches: [main, 'claude/*']
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  SCHEME: Enchanted
+  PROJECT: Enchanted.xcodeproj
+
+jobs:
+  build-simulator:
+    name: Build iOS Simulator
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve Swift Package Dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT" \
+            -scheme "$SCHEME"
+
+      - name: Build iOS Simulator App
+        run: |
+          xcodebuild build \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -configuration Release \
+            -derivedDataPath "${{ runner.temp }}/DerivedData" \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            DEVELOPMENT_TEAM="" \
+            ONLY_ACTIVE_ARCH=YES \
+            SWIFT_STRICT_CONCURRENCY=minimal \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
+            GCC_TREAT_WARNINGS_AS_ERRORS=NO 2>&1 | tee build.log
+
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "=== BUILD FAILED - Last 100 lines of output ==="
+            tail -100 build.log
+            exit 1
+          fi
+
+      - name: Prepare Simulator App
+        run: |
+          mkdir -p "${{ runner.temp }}/Export"
+
+          APP_PATH=$(find "${{ runner.temp }}/DerivedData/Build/Products/Release-iphonesimulator" -name "*.app" -type d | head -1)
+
+          if [ -n "$APP_PATH" ]; then
+            echo "Found simulator app at: $APP_PATH"
+            cp -R "$APP_PATH" "${{ runner.temp }}/Export/"
+
+            # Create a zip for easier download
+            cd "${{ runner.temp }}/Export"
+            zip -r "${{ runner.temp }}/Enchanted-Simulator.zip" "$(basename "$APP_PATH")"
+          else
+            echo "Error: No .app found in build products"
+            find "${{ runner.temp }}/DerivedData" -name "*.app" -type d
+            exit 1
+          fi
+
+      - name: Upload Simulator App
+        uses: actions/upload-artifact@v4
+        with:
+          name: Enchanted-iOS-Simulator
+          path: ${{ runner.temp }}/Enchanted-Simulator.zip
+          if-no-files-found: warn
+
+  build-device:
+    name: Build iOS Device
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve Swift Package Dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT" \
+            -scheme "$SCHEME"
+
+      - name: Build iOS Device App
+        run: |
+          xcodebuild build \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination 'generic/platform=iOS' \
+            -configuration Release \
+            -derivedDataPath "${{ runner.temp }}/DerivedData" \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            DEVELOPMENT_TEAM="" \
+            ONLY_ACTIVE_ARCH=NO \
+            SWIFT_STRICT_CONCURRENCY=minimal \
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
+            GCC_TREAT_WARNINGS_AS_ERRORS=NO 2>&1 | tee build.log
+
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "=== BUILD FAILED - Last 100 lines of output ==="
+            tail -100 build.log
+            exit 1
+          fi
+
+      - name: Create IPA
+        run: |
+          mkdir -p "${{ runner.temp }}/Payload"
+
+          APP_PATH=$(find "${{ runner.temp }}/DerivedData/Build/Products/Release-iphoneos" -name "*.app" -type d | head -1)
+
+          if [ -n "$APP_PATH" ]; then
+            echo "Found device app at: $APP_PATH"
+            cp -R "$APP_PATH" "${{ runner.temp }}/Payload/"
+
+            cd "${{ runner.temp }}"
+            zip -r "Enchanted.ipa" Payload
+          else
+            echo "Error: No .app found in build products"
+            find "${{ runner.temp }}/DerivedData" -name "*.app" -type d
+            exit 1
+          fi
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Enchanted-iOS-IPA
+          path: ${{ runner.temp }}/Enchanted.ipa
+          if-no-files-found: warn
+
+  release:
+    name: Create Release
+    needs: [build-simulator, build-device]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download Simulator Build
+        uses: actions/download-artifact@v4
+        with:
+          name: Enchanted-iOS-Simulator
+          path: ./artifacts
+
+      - name: Download IPA
+        uses: actions/download-artifact@v4
+        with:
+          name: Enchanted-iOS-IPA
+          path: ./artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            ./artifacts/*.ipa
+            ./artifacts/*.zip
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -39,7 +39,7 @@ jobs:
           xcodebuild build \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             -configuration Release \
             -derivedDataPath "${{ runner.temp }}/DerivedData" \
             CODE_SIGN_IDENTITY="-" \

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Build macOS App
         run: |
           # Build the app with a known derived data path (arm64 only for GitHub runners)
+          # Use -hideShellScriptEnvironment to reduce noise but keep errors visible
           xcodebuild build \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
@@ -49,7 +50,15 @@ jobs:
             DEVELOPMENT_TEAM="" \
             ONLY_ACTIVE_ARCH=YES \
             SWIFT_STRICT_CONCURRENCY=minimal \
-            SWIFT_UPCOMING_FEATURE_STRICT_CONCURRENCY=NO
+            SWIFT_TREAT_WARNINGS_AS_ERRORS=NO \
+            GCC_TREAT_WARNINGS_AS_ERRORS=NO 2>&1 | tee build.log
+
+          # If build failed, show the last 100 lines for debugging
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "=== BUILD FAILED - Last 100 lines of output ==="
+            tail -100 build.log
+            exit 1
+          fi
 
       - name: Prepare App for Distribution
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -36,84 +36,47 @@ jobs:
 
       - name: Build macOS App
         run: |
+          # Build the app with a known derived data path
           xcodebuild build \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
             -destination 'platform=macOS' \
             -configuration Release \
+            -derivedDataPath "${{ runner.temp }}/DerivedData" \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            DEVELOPMENT_TEAM="" \
-            | xcpretty || true
+            DEVELOPMENT_TEAM=""
 
-      - name: Archive macOS App
+      - name: Prepare App for Distribution
         run: |
-          xcodebuild archive \
-            -project "$PROJECT" \
-            -scheme "$SCHEME" \
-            -destination 'generic/platform=macOS' \
-            -configuration Release \
-            -archivePath ${{ runner.temp }}/Enchanted.xcarchive \
-            CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            DEVELOPMENT_TEAM="" \
-            | xcpretty || true
+          # Find and copy the built app
+          mkdir -p "${{ runner.temp }}/Export"
 
-      - name: Export App
-        run: |
-          # Create ExportOptions.plist for unsigned export
-          cat > ${{ runner.temp }}/ExportOptions.plist << 'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>method</key>
-              <string>mac-application</string>
-              <key>signingStyle</key>
-              <string>automatic</string>
-              <key>stripSwiftSymbols</key>
-              <true/>
-              <key>teamID</key>
-              <string></string>
-              <key>destination</key>
-              <string>export</string>
-          </dict>
-          </plist>
-          EOF
+          APP_PATH=$(find "${{ runner.temp }}/DerivedData/Build/Products/Release" -name "*.app" -type d | head -1)
 
-          # Export the archive - try direct copy if exportArchive fails (common for unsigned)
-          xcodebuild -exportArchive \
-            -archivePath ${{ runner.temp }}/Enchanted.xcarchive \
-            -exportOptionsPlist ${{ runner.temp }}/ExportOptions.plist \
-            -exportPath ${{ runner.temp }}/Export \
-            -allowProvisioningUpdates || \
-          cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/Enchanted.app" "${{ runner.temp }}/Export/" || \
-          mkdir -p "${{ runner.temp }}/Export" && cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/"*.app "${{ runner.temp }}/Export/"
+          if [ -n "$APP_PATH" ]; then
+            echo "Found app at: $APP_PATH"
+            cp -R "$APP_PATH" "${{ runner.temp }}/Export/"
+          else
+            echo "Error: No .app found in build products"
+            find "${{ runner.temp }}/DerivedData" -name "*.app" -type d
+            exit 1
+          fi
 
       - name: Create DMG
         run: |
-          # Install create-dmg if not available
+          # Install create-dmg
           brew install create-dmg || true
 
-          # Find the app
-          APP_PATH=$(find ${{ runner.temp }}/Export -name "*.app" -type d | head -1)
+          APP_PATH="${{ runner.temp }}/Export/Enchanted.app"
 
-          if [ -z "$APP_PATH" ]; then
-            # Fallback: copy from archive
-            mkdir -p ${{ runner.temp }}/Export
-            cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/"*.app "${{ runner.temp }}/Export/" || true
-            APP_PATH=$(find ${{ runner.temp }}/Export -name "*.app" -type d | head -1)
-          fi
-
-          if [ -n "$APP_PATH" ]; then
+          if [ -d "$APP_PATH" ]; then
             echo "Creating DMG from: $APP_PATH"
 
-            # Create DMG
+            # Try create-dmg first, fall back to hdiutil
             create-dmg \
               --volname "Enchanted" \
-              --volicon "$APP_PATH/Contents/Resources/AppIcon.icns" \
               --window-pos 200 120 \
               --window-size 600 400 \
               --icon-size 100 \
@@ -124,7 +87,8 @@ jobs:
               "$APP_PATH" || \
             hdiutil create -volname "Enchanted" -srcfolder "$APP_PATH" -ov -format UDZO "${{ runner.temp }}/Enchanted.dmg"
           else
-            echo "No .app found, skipping DMG creation"
+            echo "No .app found at $APP_PATH"
+            ls -la "${{ runner.temp }}/Export/" || true
             exit 1
           fi
 
@@ -132,7 +96,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Enchanted-macOS-App
-          path: ${{ runner.temp }}/Export/*.app
+          path: ${{ runner.temp }}/Export/Enchanted.app
           if-no-files-found: warn
 
       - name: Upload DMG Artifact
@@ -141,14 +105,6 @@ jobs:
           name: Enchanted-macOS-DMG
           path: ${{ runner.temp }}/Enchanted.dmg
           if-no-files-found: warn
-
-      - name: Upload Archive (for debugging)
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: Enchanted-xcarchive
-          path: ${{ runner.temp }}/Enchanted.xcarchive
-          if-no-files-found: ignore
 
   # Optional: Create a release when a tag is pushed
   release:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -36,17 +36,18 @@ jobs:
 
       - name: Build macOS App
         run: |
-          # Build the app with a known derived data path
+          # Build the app with a known derived data path (arm64 only for GitHub runners)
           xcodebuild build \
             -project "$PROJECT" \
             -scheme "$SCHEME" \
-            -destination 'platform=macOS' \
+            -destination 'platform=macOS,arch=arm64' \
             -configuration Release \
             -derivedDataPath "${{ runner.temp }}/DerivedData" \
             CODE_SIGN_IDENTITY="-" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            DEVELOPMENT_TEAM=""
+            DEVELOPMENT_TEAM="" \
+            ONLY_ACTIVE_ARCH=YES
 
       - name: Prepare App for Distribution
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,7 +2,7 @@ name: Build macOS App
 
 on:
   push:
-    branches: [main, 'claude/*']
+    branches: [main]
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,174 @@
+name: Build macOS App
+
+on:
+  push:
+    branches: [main, 'claude/*']
+    tags:
+      - 'v*'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  SCHEME: Enchanted
+  PROJECT: Enchanted.xcodeproj
+
+jobs:
+  build:
+    name: Build macOS App
+    runs-on: macos-14
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app/Contents/Developer
+
+      - name: Show Xcode version
+        run: xcodebuild -version
+
+      - name: Resolve Swift Package Dependencies
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "$PROJECT" \
+            -scheme "$SCHEME"
+
+      - name: Build macOS App
+        run: |
+          xcodebuild build \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination 'platform=macOS' \
+            -configuration Release \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            DEVELOPMENT_TEAM="" \
+            | xcpretty || true
+
+      - name: Archive macOS App
+        run: |
+          xcodebuild archive \
+            -project "$PROJECT" \
+            -scheme "$SCHEME" \
+            -destination 'generic/platform=macOS' \
+            -configuration Release \
+            -archivePath ${{ runner.temp }}/Enchanted.xcarchive \
+            CODE_SIGN_IDENTITY="-" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            DEVELOPMENT_TEAM="" \
+            | xcpretty || true
+
+      - name: Export App
+        run: |
+          # Create ExportOptions.plist for unsigned export
+          cat > ${{ runner.temp }}/ExportOptions.plist << 'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>mac-application</string>
+              <key>signingStyle</key>
+              <string>automatic</string>
+              <key>stripSwiftSymbols</key>
+              <true/>
+              <key>teamID</key>
+              <string></string>
+              <key>destination</key>
+              <string>export</string>
+          </dict>
+          </plist>
+          EOF
+
+          # Export the archive - try direct copy if exportArchive fails (common for unsigned)
+          xcodebuild -exportArchive \
+            -archivePath ${{ runner.temp }}/Enchanted.xcarchive \
+            -exportOptionsPlist ${{ runner.temp }}/ExportOptions.plist \
+            -exportPath ${{ runner.temp }}/Export \
+            -allowProvisioningUpdates || \
+          cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/Enchanted.app" "${{ runner.temp }}/Export/" || \
+          mkdir -p "${{ runner.temp }}/Export" && cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/"*.app "${{ runner.temp }}/Export/"
+
+      - name: Create DMG
+        run: |
+          # Install create-dmg if not available
+          brew install create-dmg || true
+
+          # Find the app
+          APP_PATH=$(find ${{ runner.temp }}/Export -name "*.app" -type d | head -1)
+
+          if [ -z "$APP_PATH" ]; then
+            # Fallback: copy from archive
+            mkdir -p ${{ runner.temp }}/Export
+            cp -R "${{ runner.temp }}/Enchanted.xcarchive/Products/Applications/"*.app "${{ runner.temp }}/Export/" || true
+            APP_PATH=$(find ${{ runner.temp }}/Export -name "*.app" -type d | head -1)
+          fi
+
+          if [ -n "$APP_PATH" ]; then
+            echo "Creating DMG from: $APP_PATH"
+
+            # Create DMG
+            create-dmg \
+              --volname "Enchanted" \
+              --volicon "$APP_PATH/Contents/Resources/AppIcon.icns" \
+              --window-pos 200 120 \
+              --window-size 600 400 \
+              --icon-size 100 \
+              --icon "Enchanted.app" 150 185 \
+              --hide-extension "Enchanted.app" \
+              --app-drop-link 450 185 \
+              "${{ runner.temp }}/Enchanted.dmg" \
+              "$APP_PATH" || \
+            hdiutil create -volname "Enchanted" -srcfolder "$APP_PATH" -ov -format UDZO "${{ runner.temp }}/Enchanted.dmg"
+          else
+            echo "No .app found, skipping DMG creation"
+            exit 1
+          fi
+
+      - name: Upload App Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Enchanted-macOS-App
+          path: ${{ runner.temp }}/Export/*.app
+          if-no-files-found: warn
+
+      - name: Upload DMG Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Enchanted-macOS-DMG
+          path: ${{ runner.temp }}/Enchanted.dmg
+          if-no-files-found: warn
+
+      - name: Upload Archive (for debugging)
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: Enchanted-xcarchive
+          path: ${{ runner.temp }}/Enchanted.xcarchive
+          if-no-files-found: ignore
+
+  # Optional: Create a release when a tag is pushed
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - name: Download DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: Enchanted-macOS-DMG
+          path: ./artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ./artifacts/*.dmg
+          draft: true
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -48,7 +48,8 @@ jobs:
             CODE_SIGNING_ALLOWED=NO \
             DEVELOPMENT_TEAM="" \
             ONLY_ACTIVE_ARCH=YES \
-            SWIFT_STRICT_CONCURRENCY=minimal
+            SWIFT_STRICT_CONCURRENCY=minimal \
+            SWIFT_UPCOMING_FEATURE_STRICT_CONCURRENCY=NO
 
       - name: Prepare App for Distribution
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,7 +47,8 @@ jobs:
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             DEVELOPMENT_TEAM="" \
-            ONLY_ACTIVE_ARCH=YES
+            ONLY_ACTIVE_ARCH=YES \
+            SWIFT_STRICT_CONCURRENCY=minimal
 
       - name: Prepare App for Distribution
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-ipados:
+    name: Build iPadOS
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Build for iPadOS
+        run: |
+          xcodebuild build \
+            -project Enchanted.xcodeproj \
+            -scheme Enchanted \
+            -destination 'platform=iOS Simulator,name=iPad Pro 13-inch (M4),OS=latest' \
+            CODE_SIGNING_ALLOWED=NO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.runtime/
+.claude/
+.beads/
+.logs/

--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		FF1002322B2483A20011A4DC /* Colours+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1002312B2483A20011A4DC /* Colours+Extension.swift */; };
 		FF1002392B24BBF20011A4DC /* Chat.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1002382B24BBF20011A4DC /* Chat.swift */; };
 		FF10023E2B24F4900011A4DC /* OllamaService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10023D2B24F4900011A4DC /* OllamaService.swift */; };
+		AABB00012CE8000100000001 /* OpenAIService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB00022CE8000100000001 /* OpenAIService.swift */; };
 		FF1002402B24F7320011A4DC /* SideBarMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF10023F2B24F7320011A4DC /* SideBarMenuView.swift */; };
 		FF1002442B25BB730011A4DC /* ConversationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1002432B25BB730011A4DC /* ConversationStore.swift */; };
 		FF1002462B25BCE70011A4DC /* LanguageModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1002452B25BCE70011A4DC /* LanguageModelStore.swift */; };
@@ -114,6 +115,7 @@
 		FF1002312B2483A20011A4DC /* Colours+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Colours+Extension.swift"; sourceTree = "<group>"; };
 		FF1002382B24BBF20011A4DC /* Chat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Chat.swift; sourceTree = "<group>"; };
 		FF10023D2B24F4900011A4DC /* OllamaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OllamaService.swift; sourceTree = "<group>"; };
+		AABB00022CE8000100000001 /* OpenAIService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIService.swift; sourceTree = "<group>"; };
 		FF10023F2B24F7320011A4DC /* SideBarMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideBarMenuView.swift; sourceTree = "<group>"; };
 		FF1002432B25BB730011A4DC /* ConversationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationStore.swift; sourceTree = "<group>"; };
 		FF1002452B25BCE70011A4DC /* LanguageModelStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelStore.swift; sourceTree = "<group>"; };
@@ -524,6 +526,7 @@
 				FF0146CC2B3DADCA00A2A9F6 /* HapticsService.swift */,
 				FF2F03482B796A6500349855 /* HotkeyService.swift */,
 				FF10023D2B24F4900011A4DC /* OllamaService.swift */,
+				AABB00022CE8000100000001 /* OpenAIService.swift */,
 				FF10024F2B25C79F0011A4DC /* SwiftDataService.swift */,
 				FF6B7B122B3EE7AC00E8FEA3 /* Throttler.swift */,
 				FFCF00F02C03209A00590E79 /* SpeechService.swift */,
@@ -665,6 +668,7 @@
 				FF10024C2B25BEA00011A4DC /* MessageSD.swift in Sources */,
 				FFCF00F12C03209A00590E79 /* SpeechService.swift in Sources */,
 				FF10023E2B24F4900011A4DC /* OllamaService.swift in Sources */,
+				AABB00012CE8000100000001 /* OpenAIService.swift in Sources */,
 				FFBBF48C2B35051D008D611C /* UIImage+Extension.swift in Sources */,
 				FF1002302B2482BA0011A4DC /* ChatMessageView.swift in Sources */,
 				FF1002322B2483A20011A4DC /* Colours+Extension.swift in Sources */,

--- a/Enchanted/Models/LanguageModel.swift
+++ b/Enchanted/Models/LanguageModel.swift
@@ -13,6 +13,16 @@ struct LanguageModel {
     var imageSupport: Bool
 }
 
-enum ModelProvider: Codable {
-    case ollama
+enum ModelProvider: String, Codable, CaseIterable {
+    case ollama = "ollama"
+    case openAI = "openai"
+
+    var displayName: String {
+        switch self {
+        case .ollama:
+            return "Ollama"
+        case .openAI:
+            return "OpenAI Compatible"
+        }
+    }
 }

--- a/Enchanted/Services/OpenAIService.swift
+++ b/Enchanted/Services/OpenAIService.swift
@@ -1,0 +1,333 @@
+//
+//  OpenAIService.swift
+//  Enchanted
+//
+//  Created for OpenAI-compatible gateway support (LiteLLM, etc.)
+//
+
+import Foundation
+import Combine
+
+// MARK: - OpenAI API Request/Response Models
+
+struct OpenAIChatMessage: Codable {
+    let role: String
+    let content: OpenAIMessageContent
+
+    enum CodingKeys: String, CodingKey {
+        case role, content
+    }
+
+    init(role: String, content: String, imageBase64: String? = nil) {
+        self.role = role
+        if let image = imageBase64 {
+            self.content = .array([
+                .init(type: "text", text: content, imageUrl: nil),
+                .init(type: "image_url", text: nil, imageUrl: .init(url: "data:image/jpeg;base64,\(image)"))
+            ])
+        } else {
+            self.content = .string(content)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        role = try container.decode(String.self, forKey: .role)
+
+        if let stringContent = try? container.decode(String.self, forKey: .content) {
+            content = .string(stringContent)
+        } else {
+            content = try container.decode(OpenAIMessageContent.self, forKey: .content)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+    }
+}
+
+enum OpenAIMessageContent: Codable {
+    case string(String)
+    case array([OpenAIContentPart])
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let str):
+            try container.encode(str)
+        case .array(let parts):
+            try container.encode(parts)
+        }
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .string(str)
+        } else {
+            self = .array(try container.decode([OpenAIContentPart].self))
+        }
+    }
+}
+
+struct OpenAIContentPart: Codable {
+    let type: String
+    let text: String?
+    let imageUrl: OpenAIImageUrl?
+
+    enum CodingKeys: String, CodingKey {
+        case type, text
+        case imageUrl = "image_url"
+    }
+}
+
+struct OpenAIImageUrl: Codable {
+    let url: String
+}
+
+struct OpenAIChatRequest: Codable {
+    let model: String
+    let messages: [OpenAIChatMessage]
+    let stream: Bool
+    let temperature: Double?
+
+    init(model: String, messages: [OpenAIChatMessage], stream: Bool = true, temperature: Double? = nil) {
+        self.model = model
+        self.messages = messages
+        self.stream = stream
+        self.temperature = temperature
+    }
+}
+
+struct OpenAIChatResponseChunk: Codable {
+    let id: String?
+    let object: String?
+    let created: Int?
+    let model: String?
+    let choices: [OpenAIChoice]?
+}
+
+struct OpenAIChoice: Codable {
+    let index: Int?
+    let delta: OpenAIDelta?
+    let finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case index, delta
+        case finishReason = "finish_reason"
+    }
+}
+
+struct OpenAIDelta: Codable {
+    let role: String?
+    let content: String?
+}
+
+struct OpenAIModelResponse: Codable {
+    let object: String
+    let data: [OpenAIModel]
+}
+
+struct OpenAIModel: Codable {
+    let id: String
+    let object: String?
+    let created: Int?
+    let ownedBy: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, object, created
+        case ownedBy = "owned_by"
+    }
+}
+
+// MARK: - OpenAI Chat Response (for streaming)
+
+struct OpenAIChatResponse {
+    let content: String?
+    let done: Bool
+}
+
+// MARK: - OpenAI Service
+
+class OpenAIService: @unchecked Sendable {
+    static let shared = OpenAIService()
+
+    private var baseURL: URL
+    private var apiKey: String
+    private var session: URLSession
+
+    init() {
+        self.baseURL = URL(string: "http://localhost:4000/v1")!
+        self.apiKey = ""
+        self.session = URLSession.shared
+        initEndpoint()
+    }
+
+    func initEndpoint(url: String? = nil, apiKey: String? = nil) {
+        let defaultUrl = "http://localhost:4000/v1"
+        let localStorageUrl = UserDefaults.standard.string(forKey: "openAIUri")
+        let storedApiKey = UserDefaults.standard.string(forKey: "openAIApiKey") ?? ""
+
+        if var openAIUrl = [localStorageUrl, defaultUrl].compactMap({$0}).filter({$0.count > 0}).first {
+            if !openAIUrl.contains("http") {
+                openAIUrl = "http://" + openAIUrl
+            }
+
+            // Ensure URL ends with /v1
+            if !openAIUrl.hasSuffix("/v1") && !openAIUrl.hasSuffix("/v1/") {
+                openAIUrl = openAIUrl.trimmingCharacters(in: CharacterSet(charactersIn: "/")) + "/v1"
+            }
+
+            if let url = URL(string: openAIUrl) {
+                self.baseURL = url
+            }
+        }
+
+        self.apiKey = apiKey ?? storedApiKey
+    }
+
+    func getModels() async throws -> [LanguageModel] {
+        let url = baseURL.appendingPathComponent("models")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw OpenAIError.invalidResponse
+        }
+
+        let modelResponse = try JSONDecoder().decode(OpenAIModelResponse.self, from: data)
+
+        return modelResponse.data.map { model in
+            // Detect image support based on model name patterns
+            let supportsImages = model.id.lowercased().contains("vision") ||
+                                 model.id.lowercased().contains("gpt-4o") ||
+                                 model.id.lowercased().contains("gpt-4-turbo") ||
+                                 model.id.lowercased().contains("claude-3") ||
+                                 model.id.lowercased().contains("llava")
+
+            return LanguageModel(
+                name: model.id,
+                provider: .openAI,
+                imageSupport: supportsImages
+            )
+        }
+    }
+
+    func reachable() async -> Bool {
+        let url = baseURL.appendingPathComponent("models")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 5
+        if !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (_, response) = try await session.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse {
+                return httpResponse.statusCode == 200
+            }
+            return false
+        } catch {
+            return false
+        }
+    }
+
+    func chat(model: String, messages: [OpenAIChatMessage], temperature: Double? = nil) -> AnyPublisher<OpenAIChatResponse, Error> {
+        let subject = PassthroughSubject<OpenAIChatResponse, Error>()
+
+        Task {
+            do {
+                let url = baseURL.appendingPathComponent("chat/completions")
+                var request = URLRequest(url: url)
+                request.httpMethod = "POST"
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+                if !apiKey.isEmpty {
+                    request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+                }
+
+                let chatRequest = OpenAIChatRequest(
+                    model: model,
+                    messages: messages,
+                    stream: true,
+                    temperature: temperature
+                )
+
+                request.httpBody = try JSONEncoder().encode(chatRequest)
+
+                let (asyncBytes, response) = try await session.bytes(for: request)
+
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    subject.send(completion: .failure(OpenAIError.invalidResponse))
+                    return
+                }
+
+                if httpResponse.statusCode != 200 {
+                    subject.send(completion: .failure(OpenAIError.httpError(statusCode: httpResponse.statusCode)))
+                    return
+                }
+
+                for try await line in asyncBytes.lines {
+                    if line.hasPrefix("data: ") {
+                        let jsonString = String(line.dropFirst(6))
+
+                        if jsonString == "[DONE]" {
+                            subject.send(OpenAIChatResponse(content: nil, done: true))
+                            subject.send(completion: .finished)
+                            return
+                        }
+
+                        if let jsonData = jsonString.data(using: .utf8) {
+                            do {
+                                let chunk = try JSONDecoder().decode(OpenAIChatResponseChunk.self, from: jsonData)
+                                if let content = chunk.choices?.first?.delta?.content {
+                                    subject.send(OpenAIChatResponse(content: content, done: false))
+                                }
+                                if chunk.choices?.first?.finishReason != nil {
+                                    subject.send(OpenAIChatResponse(content: nil, done: true))
+                                }
+                            } catch {
+                                // Skip malformed chunks
+                                print("Failed to decode chunk: \(error)")
+                            }
+                        }
+                    }
+                }
+
+                subject.send(completion: .finished)
+            } catch {
+                subject.send(completion: .failure(error))
+            }
+        }
+
+        return subject.eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Errors
+
+enum OpenAIError: Error, LocalizedError {
+    case invalidResponse
+    case httpError(statusCode: Int)
+    case decodingError
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            return "Invalid response from server"
+        case .httpError(let statusCode):
+            return "HTTP error: \(statusCode)"
+        case .decodingError:
+            return "Failed to decode response"
+        }
+    }
+}

--- a/Enchanted/Stores/AppStore.swift
+++ b/Enchanted/Stores/AppStore.swift
@@ -64,8 +64,14 @@ final class AppStore {
     }
 
     private func reachable() async -> Bool {
-        let status = await OllamaService.shared.reachable()
-        return status
+        let selectedProvider = UserDefaults.standard.string(forKey: "selectedProvider") ?? ModelProvider.ollama.rawValue
+        let provider = ModelProvider(rawValue: selectedProvider) ?? .ollama
+
+        if provider == .ollama {
+            return await OllamaService.shared.reachable()
+        } else {
+            return await OpenAIService.shared.reachable()
+        }
     }
     
     @MainActor func uiLog(message: String, status: NotificationMessage.Status) {

--- a/Enchanted/Stores/LanguageModelStore.swift
+++ b/Enchanted/Stores/LanguageModelStore.swift
@@ -47,15 +47,29 @@ final class LanguageModelStore {
     }
     
     func loadModels() async throws {
-        let remoteModels = try await OllamaService.shared.getModels()
-        try await swiftDataService.saveModels(models: remoteModels.map{LanguageModelSD(name: $0.name, imageSupport: $0.imageSupport, modelProvider: .ollama)})
-        
+        let selectedProvider = UserDefaults.standard.string(forKey: "selectedProvider") ?? ModelProvider.ollama.rawValue
+        let provider = ModelProvider(rawValue: selectedProvider) ?? .ollama
+
+        let remoteModels: [LanguageModel]
+        if provider == .ollama {
+            remoteModels = try await OllamaService.shared.getModels()
+        } else {
+            remoteModels = try await OpenAIService.shared.getModels()
+        }
+
+        try await swiftDataService.saveModels(models: remoteModels.map{LanguageModelSD(name: $0.name, imageSupport: $0.imageSupport, modelProvider: provider)})
+
         let storedModels = (try? await swiftDataService.fetchModels()) ?? []
-        
+
         DispatchQueue.main.async {
             let remoteModelNames = remoteModels.map { $0.name }
             self.models = storedModels.filter{remoteModelNames.contains($0.name)}
         }
+    }
+
+    func currentProvider() -> ModelProvider {
+        let selectedProvider = UserDefaults.standard.string(forKey: "selectedProvider") ?? ModelProvider.ollama.rawValue
+        return ModelProvider(rawValue: selectedProvider) ?? .ollama
     }
     
     func deleteAllModels() async throws {

--- a/Enchanted/UI/Shared/Chat/Components/EmptyConversaitonView.swift
+++ b/Enchanted/UI/Shared/Chat/Components/EmptyConversaitonView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 
 struct EmptyConversaitonView: View, KeyboardReadable {
     @Environment(\.openURL) private var openURL
+#if os(iOS)
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+#endif
     @State var showPromptsAnimation = false
     @State var prompts: [SamplePrompts] = []
     var sendPrompt: (String) -> ()
@@ -16,12 +19,22 @@ struct EmptyConversaitonView: View, KeyboardReadable {
 #if os(iOS)
     @State var isKeyboardVisible = false
 #endif
-    
+
 #if os(macOS)
     var columns = Array.init(repeating: GridItem(.flexible(), spacing: 15), count: 4)
-#else
-    var columns = [GridItem(.flexible()), GridItem(.flexible())]
 #endif
+
+    private var gridColumns: [GridItem] {
+#if os(macOS)
+        return columns
+#else
+        if horizontalSizeClass == .regular {
+            return Array(repeating: GridItem(.flexible(), spacing: 15), count: 4)
+        } else {
+            return [GridItem(.flexible()), GridItem(.flexible())]
+        }
+#endif
+    }
     @State var visibleItems = Set<Int>()
     
     func onFreysaTap() {
@@ -61,7 +74,7 @@ struct EmptyConversaitonView: View, KeyboardReadable {
 //                            }
                 }
                 
-                LazyVGrid(columns: columns, alignment: .leading, spacing: 15) {
+                LazyVGrid(columns: gridColumns, alignment: .leading, spacing: 15) {
                     ForEach(0..<prompts.prefix(4).count, id: \.self) { index in
                         Button(action: {
                             withAnimation {

--- a/Enchanted/UI/iOS/ChatView_iOS.swift
+++ b/Enchanted/UI/iOS/ChatView_iOS.swift
@@ -29,8 +29,7 @@ struct ChatView: View {
     @State private var editMessage: MessageSD?
     @FocusState private var isFocusedInput: Bool
     @StateObject var speechRecognizer = SpeechRecognizer()
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    
+
     /// Image selection
     @State private var pickerSelectorActive: PhotosPickerItem?
     @State private var selectedImage: Image?

--- a/Enchanted/UI/iOS/ChatView_iOS.swift
+++ b/Enchanted/UI/iOS/ChatView_iOS.swift
@@ -21,13 +21,14 @@ struct ChatView: View {
     var reachable: Bool
     var onSelectModel: @MainActor (_ model: LanguageModelSD?) -> ()
     var userInitials: String
-    
+
     private var selectedModel: LanguageModelSD?
     @State private var message = ""
     @State private var isRecording = false
     @State private var editMessage: MessageSD?
     @FocusState private var isFocusedInput: Bool
     @StateObject var speechRecognizer = SpeechRecognizer()
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     
     /// Image selection
     @State private var pickerSelectorActive: PhotosPickerItem?
@@ -86,33 +87,37 @@ struct ChatView: View {
     
     var header: some View {
         HStack(alignment: .center) {
-            Button(action: onMenuTap) {
-                Image(systemName: "line.3.horizontal")
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 22)
-                    .foregroundColor(Color(.label))
+            if horizontalSizeClass == .compact {
+                Button(action: onMenuTap) {
+                    Image(systemName: "line.3.horizontal")
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 22)
+                        .foregroundColor(Color(.label))
+                }
             }
-            
+
             Spacer()
-            
+
             ModelSelectorView(
                 modelsList: modelsList,
                 selectedModel: selectedModel,
                 onSelectModel: onSelectModel
             )
             .showIf(!modelsList.isEmpty)
-            
+
             Spacer()
-            
-            Button(action: onNewConversationTap) {
-                Image(systemName: "square.and.pencil")
-                    .renderingMode(.template)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 22)
-                    .foregroundColor(Color(.label))
+
+            if horizontalSizeClass == .compact {
+                Button(action: onNewConversationTap) {
+                    Image(systemName: "square.and.pencil")
+                        .renderingMode(.template)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 22)
+                        .foregroundColor(Color(.label))
+                }
             }
         }
     }

--- a/Enchanted/UI/iOS/ChatView_iOS.swift
+++ b/Enchanted/UI/iOS/ChatView_iOS.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import PhotosUI
 
 struct ChatView: View {
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     var conversation: ConversationSD?
     var messages: [MessageSD]
     var modelsList: [LanguageModelSD]
@@ -21,7 +22,7 @@ struct ChatView: View {
     var reachable: Bool
     var onSelectModel: @MainActor (_ model: LanguageModelSD?) -> ()
     var userInitials: String
-    
+
     private var selectedModel: LanguageModelSD?
     @State private var message = ""
     @State private var isRecording = false
@@ -182,9 +183,11 @@ struct ChatView: View {
     
     var body: some View {
         VStack {
-            header
-                .padding(.horizontal)
-            
+            if horizontalSizeClass == .compact {
+                header
+                    .padding(.horizontal)
+            }
+
             if conversation != nil {
                 MessageListView(
                     messages: messages,
@@ -216,6 +219,23 @@ struct ChatView: View {
             if let newMessage = newMessage {
                 message = newMessage.content
                 isFocusedInput = true
+            }
+        }
+        .toolbar {
+            if horizontalSizeClass == .regular {
+                ToolbarItem(placement: .principal) {
+                    ModelSelectorView(
+                        modelsList: modelsList,
+                        selectedModel: selectedModel,
+                        onSelectModel: onSelectModel
+                    )
+                    .showIf(!modelsList.isEmpty)
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Button(action: onNewConversationTap) {
+                        Image(systemName: "square.and.pencil")
+                    }
+                }
             }
         }
     }

--- a/Enchanted/UI/macOS/PromptPanel/PanelCompletionsVM.swift
+++ b/Enchanted/UI/macOS/PromptPanel/PanelCompletionsVM.swift
@@ -81,7 +81,7 @@ final class CompletionsPanelVM {
                     generation = OpenAIService.shared.chat(
                         model: model.name,
                         messages: openAIMessages,
-                        temperature: completion.modelTemperature ?? 0.8
+                        temperature: completion.modelTemperature.map { Double($0) } ?? 0.8
                     )
                     .sink(receiveCompletion: { [weak self] completion in
                         switch completion {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,130 @@
+# Installing Unsigned Builds
+
+This guide covers installing Enchanted from unsigned builds (DMG for macOS, IPA for iOS) downloaded from GitHub releases or CI artifacts.
+
+## macOS Installation
+
+### Method 1: Remove Quarantine Attribute (Recommended)
+
+When you download an unsigned app, macOS marks it with a quarantine attribute. Remove it using Terminal:
+
+```bash
+xattr -cr /path/to/Enchanted.app
+```
+
+Or if you downloaded the DMG:
+
+```bash
+xattr -cr /path/to/Enchanted.dmg
+```
+
+Then open the DMG and drag Enchanted to your Applications folder.
+
+### Method 2: System Settings
+
+1. Double-click the app to attempt opening it
+2. You'll see a message that the app "cannot be opened because the developer cannot be verified"
+3. Open **System Settings** > **Privacy & Security**
+4. Scroll down to find the message about Enchanted being blocked
+5. Click **Open Anyway**
+6. Enter your password when prompted
+
+### Troubleshooting macOS
+
+**"App is damaged and can't be opened"**
+- Run `xattr -cr /path/to/Enchanted.app` in Terminal
+- If using a DMG, run the command on the DMG file first, then on the extracted app
+
+**App won't open after allowing in System Settings**
+- Try right-clicking the app and selecting "Open" instead of double-clicking
+- Ensure you've removed the quarantine attribute with `xattr -cr`
+
+---
+
+## iOS Installation
+
+Since unsigned iOS apps cannot be installed directly, you need to use a sideloading tool. Below are the most common methods.
+
+### Prerequisites
+
+- An Apple ID (free accounts work but apps expire after 7 days)
+- The Enchanted `.ipa` file downloaded from releases
+- A computer (Mac or Windows, depending on the tool)
+
+### Method 1: AltStore (Recommended)
+
+AltStore is a free sideloading solution that automatically refreshes apps before they expire.
+
+**On Mac:**
+1. Download AltServer from [altstore.io](https://altstore.io)
+2. Run AltServer (it appears in the menu bar)
+3. Connect your iPhone via USB
+4. Click the AltServer icon > Install AltStore > [Your Device]
+5. Enter your Apple ID credentials
+6. On your iPhone, trust the developer certificate in **Settings** > **General** > **VPN & Device Management**
+7. Open AltStore on your iPhone
+8. Tap the **+** button and select the Enchanted `.ipa` file
+
+**On Windows:**
+1. Install iTunes and iCloud from Apple's website (not Microsoft Store versions)
+2. Download AltServer from [altstore.io](https://altstore.io)
+3. Follow the same steps as Mac
+
+### Method 2: Sideloadly
+
+Sideloadly is a straightforward tool for one-time sideloading.
+
+1. Download Sideloadly from [sideloadly.io](https://sideloadly.io)
+2. Connect your iPhone to your computer via USB
+3. Open Sideloadly
+4. Drag the Enchanted `.ipa` file into the app window
+5. Enter your Apple ID
+6. Click "Start" to begin installation
+7. On your iPhone, trust the developer certificate in **Settings** > **General** > **VPN & Device Management**
+
+### Method 3: Apple Configurator 2 (Mac Only)
+
+Apple Configurator 2 is Apple's official tool for managing iOS devices.
+
+1. Install Apple Configurator 2 from the Mac App Store
+2. Connect your iPhone via USB and trust the computer
+3. Select your device in Apple Configurator 2
+4. Go to **Add** > **Apps**
+5. Select the Enchanted `.ipa` file
+6. The app will be installed on your device
+
+**Note:** Apple Configurator 2 requires the IPA to be signed. For unsigned IPAs, use AltStore or Sideloadly instead.
+
+### Troubleshooting iOS
+
+**"Unable to Install" error**
+- Ensure you're using a valid Apple ID
+- Free Apple IDs have a limit of 3 apps at a time
+- Try revoking existing app certificates in the sideloading tool
+
+**App crashes immediately on launch**
+- The certificate may have expired (7 days for free accounts)
+- Reinstall the app using your sideloading tool
+- With AltStore, ensure AltServer is running on your computer to auto-refresh
+
+**"Untrusted Developer" message**
+- Go to **Settings** > **General** > **VPN & Device Management**
+- Find your Apple ID under "Developer App"
+- Tap "Trust [your email]"
+
+**App won't install on iOS 17+**
+- Ensure your sideloading tool is updated to the latest version
+- Try enabling Developer Mode: **Settings** > **Privacy & Security** > **Developer Mode**
+
+---
+
+## Building from Source
+
+If you prefer to build Enchanted yourself:
+
+1. Clone the repository
+2. Open `Enchanted.xcodeproj` in Xcode
+3. Select your target device/simulator
+4. Build and run (Cmd+R)
+
+For CI-built artifacts, check the GitHub Actions workflow runs for downloadable builds.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,163 @@
+# Sideloading Installation Guide
+
+This guide covers installing unsigned builds of Enchanted on macOS and iOS devices. The official release is available on the [App Store](https://apps.apple.com/gb/app/enchanted-llm/id6474268307), but developers or testers may need to install unsigned builds directly.
+
+## macOS Installation
+
+### Method 1: Terminal (Recommended)
+
+When you download an unsigned `.app` file, macOS Gatekeeper will block it. Remove the quarantine attribute to allow execution:
+
+```bash
+xattr -cr /path/to/Enchanted.app
+```
+
+Then open the app normally by double-clicking or running:
+
+```bash
+open /path/to/Enchanted.app
+```
+
+### Method 2: System Settings
+
+1. Attempt to open the app (it will be blocked)
+2. Open **System Settings** > **Privacy & Security**
+3. Scroll to the **Security** section
+4. Find the message about Enchanted being blocked
+5. Click **Open Anyway**
+6. Confirm by clicking **Open** in the dialog
+
+### Method 3: Right-Click Open
+
+1. Right-click (or Control-click) on `Enchanted.app`
+2. Select **Open** from the context menu
+3. Click **Open** in the security dialog
+
+This bypasses Gatekeeper for that specific launch and remembers your choice.
+
+---
+
+## iOS Installation
+
+iOS requires sideloading tools to install unsigned `.ipa` files. Choose one of the following methods.
+
+### Method 1: AltStore
+
+[AltStore](https://altstore.io/) is a free sideloading tool that uses your Apple ID to sign apps.
+
+**Requirements:**
+- macOS or Windows computer
+- Apple ID (free account works)
+- Lightning/USB-C cable
+
+**Steps:**
+
+1. Download and install AltServer on your computer from [altstore.io](https://altstore.io/)
+2. Connect your iOS device via USB
+3. On macOS: Run AltServer, click the menu bar icon, select your device, and click **Install AltStore**
+4. On your iOS device, trust the developer certificate:
+   - Go to **Settings** > **General** > **VPN & Device Management**
+   - Tap your Apple ID under "Developer App"
+   - Tap **Trust**
+5. Open AltStore on your iOS device
+6. Go to **My Apps** > tap **+** > select the Enchanted `.ipa` file
+7. Enter your Apple ID credentials when prompted
+
+**Note:** Free Apple IDs allow 3 sideloaded apps and require weekly re-signing. Keep AltServer running on your computer and connect to the same Wi-Fi to enable automatic refresh.
+
+### Method 2: Sideloadly
+
+[Sideloadly](https://sideloadly.io/) is a user-friendly tool for sideloading apps.
+
+**Requirements:**
+- macOS or Windows computer
+- Apple ID
+- USB cable
+
+**Steps:**
+
+1. Download Sideloadly from [sideloadly.io](https://sideloadly.io/)
+2. Connect your iOS device via USB
+3. Open Sideloadly and drag the `.ipa` file onto the window
+4. Enter your Apple ID in the "Apple account" field
+5. Select your iOS device from the dropdown
+6. Click **Start**
+7. Enter your Apple ID password when prompted
+8. On your iOS device, trust the developer certificate:
+   - **Settings** > **General** > **VPN & Device Management**
+   - Tap your Apple ID > **Trust**
+
+### Method 3: Apple Configurator 2 (macOS only)
+
+Apple Configurator 2 is Apple's official tool for deploying apps to iOS devices.
+
+**Requirements:**
+- Mac with Apple Configurator 2 (free from Mac App Store)
+- Apple ID enrolled in Apple Developer Program or valid provisioning profile
+- USB cable
+
+**Steps:**
+
+1. Install [Apple Configurator 2](https://apps.apple.com/app/apple-configurator-2/id1037126344) from the Mac App Store
+2. Connect your iOS device via USB
+3. Open Apple Configurator 2 and select your device
+4. Go to **Add** > **Apps**
+5. Click **Choose from my Mac** and select the `.ipa` file
+6. The app will be installed on your device
+
+**Note:** Apple Configurator 2 works best with properly signed apps or when used with a developer account.
+
+---
+
+## Troubleshooting
+
+### macOS Issues
+
+**"Enchanted.app is damaged and can't be opened"**
+- Run `xattr -cr /path/to/Enchanted.app` in Terminal
+- If the error persists, re-download the file (it may be corrupted)
+
+**"Cannot be opened because the developer cannot be verified"**
+- Use any of the three methods above to bypass Gatekeeper
+- Ensure you have admin privileges on your Mac
+
+**App crashes immediately after opening**
+- Check Console.app for crash logs
+- Ensure you're running a compatible macOS version
+- Try removing and re-extracting the app
+
+### iOS Issues
+
+**"Unable to Install" error in AltStore/Sideloadly**
+- Ensure your Apple ID doesn't have two-factor authentication issues
+- Generate an app-specific password at [appleid.apple.com](https://appleid.apple.com) if needed
+- Check that your device is trusted on your computer
+
+**"Untrusted Developer" message**
+- Go to **Settings** > **General** > **VPN & Device Management**
+- Tap the developer profile and select **Trust**
+
+**App expires after 7 days (free Apple ID)**
+- Free Apple IDs require re-signing every 7 days
+- Keep AltServer running and connected to the same Wi-Fi as your device
+- Alternatively, use a paid Apple Developer account ($99/year) for 1-year signatures
+
+**"Your session has expired" in AltStore**
+- Re-enter your Apple ID credentials in AltStore settings
+- Generate a new app-specific password if using two-factor authentication
+
+**"Maximum number of apps reached" (free Apple ID)**
+- Free accounts allow only 3 sideloaded apps
+- Remove an existing sideloaded app before installing a new one
+
+**App won't open after installation**
+- Verify the `.ipa` file is not corrupted
+- Check that the app supports your iOS version
+- Try reinstalling with a fresh download
+
+### General Tips
+
+- Always download `.ipa` and `.app` files from trusted sources
+- Keep backups of your provisioning profiles and certificates
+- For development builds, ensure the correct bundle identifier is used
+- If using a corporate or school Apple ID, contact your administrator as managed IDs may have restrictions


### PR DESCRIPTION
## Summary
This PR adds support for OpenAI-compatible APIs (such as LiteLLM, OpenRouter, and Azure OpenAI) alongside the existing Ollama integration. Users can now switch between providers in settings and use any OpenAI-compatible endpoint.

## Key Changes

- **ModelProvider enum enhancement**: Added `openAI` case with `String` conformance, `CaseIterable`, and a `displayName` property for UI presentation
- **New OpenAIService**: Comprehensive service implementation supporting:
  - Model listing from OpenAI-compatible endpoints
  - Streaming chat completions with proper SSE parsing
  - Image support detection based on model name patterns
  - Bearer token authentication
  - Configurable base URL and API key via UserDefaults
- **Settings UI updates**: 
  - Added provider selector (segmented picker between Ollama and OpenAI Compatible)
  - Conditional UI sections showing relevant configuration fields for each provider
  - OpenAI section includes URI and API key fields with helpful description text
- **Provider-aware message handling**:
  - `ConversationStore` now routes requests to appropriate service based on selected provider
  - Added `convertToOpenAIMessages()` helper to transform message format
  - Separate response handlers for OpenAI streaming responses
- **Store updates**:
  - `AppStore.reachable()` checks appropriate service based on provider
  - `LanguageModelStore.loadModels()` fetches from selected provider
  - `PanelCompletionsVM` supports both providers for macOS panel completions

## Implementation Details

- OpenAI message content supports both string and array formats (for vision/image support)
- Streaming responses properly handle SSE format with `[DONE]` sentinel
- Image support is auto-detected for models containing keywords like "vision", "gpt-4o", "claude-3", "llava"
- Provider selection is persisted in UserDefaults and defaults to Ollama for backward compatibility
- Both services implement consistent interfaces for model fetching and chat operations