### PR TITLE
Improve build performance with Xcode build settings and deterministic SPM pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.build-benchmark/

--- a/Enchanted.xcodeproj/project.pbxproj
+++ b/Enchanted.xcodeproj/project.pbxproj
@@ -780,9 +780,11 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMPILATION_CACHING = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				EAGER_LINKING = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -842,6 +844,7 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COMPILATION_CACHING = YES;
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -996,16 +999,16 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AugustDev/Magnet";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = 4865f86d9baa24684dedacd6677beb2d8b30d88e;
 			};
 		};
 		FF0611EF2C04A2FB00443B33 /* XCRemoteSwiftPackageReference "Splash" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AugustDev/Splash";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = c31eba0866102be9be29391dac641ecb46795702;
 			};
 		};
 		FF1002642B2653EE0011A4DC /* XCRemoteSwiftPackageReference "ActivityIndicatorView" */ = {
@@ -1052,8 +1055,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AugustDev/OllamaKit";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = revision;
+				revision = 0079411b4568dbc821c9e2589345d3f9b9538af4;
 			};
 		};
 		FFFD00C72B94CB5E00392AE6 /* XCRemoteSwiftPackageReference "swift-async-algorithms" */ = {


### PR DESCRIPTION
## Summary

This PR enables recommended Xcode build settings and pins branch-tracked SPM dependencies to specific revisions for faster, more deterministic builds.

### Changes

- **`COMPILATION_CACHING = YES`** (Debug + Release): Caches compilation results so repeated builds of unchanged sources are served from cache. The biggest wins come from branch switching, pulling changes, and CI builds where many files remain unchanged between builds.
- **`EAGER_LINKING = YES`** (Debug): Allows the linker to start work before all compilation tasks finish, reducing wall-clock build time during development.
- **Pin Magnet, Splash, and OllamaKit** from branch tracking (`main`/`master`) to specific commit revisions: Eliminates non-deterministic SPM resolution and avoids unnecessary re-fetches when upstream branches move.

### Benchmark (Xcode 26.2, Apple Silicon)

| Metric | Before | After |
|--------|-------:|------:|
| Clean build | 19.4s | 16.6s |
| Cached clean | -- | 16.8s |
| Zero-change | 2.5s | 2.2s |

> **Cached clean** = clean build with a warm compilation cache. This is the realistic scenario for branch switching, pulling changes, or Clean Build Folder. The compilation cache lives outside DerivedData and survives product deletion.

### How these were found

Analysis was performed using [Xcode Build Optimization Agent Skills](https://github.com/AvdLee/Xcode-Build-Optimization-Agent-Skill) (not yet available, happy to invite to the private repo!), which benchmarks builds, audits project settings against best practices, and identifies optimization opportunities.

## Test plan

- [x] Project builds successfully with all changes
- [x] SPM dependencies resolve correctly with pinned revisions
- [x] No type-checking hotspots found above 100ms threshold
- [x] Benchmarked before and after changes